### PR TITLE
docs(readme): cleaned up unused badge markdown for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,7 @@ Let everyone know your app can be run instantly in the _Expo Go_ app!
 
 [![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
 
-```md
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-000.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
 
-[![runs with Expo Go](https://img.shields.io/badge/Runs%20with%20Expo%20Go-4630EB.svg?style=flat-square&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://expo.dev/client)
-```
 
 ## 👏 Contributing
 


### PR DESCRIPTION
# Why
Removed unused badge markdown from README for better readability and to avoid confusion.
# How
Deleted the extra raw markdown badge codes that were not being rendered. No functional/logic change, only documentation cleanup.
# Test Plan
Previewed README in GitHub UI
Verified that only the relevant badges remain visible
No functional changes, so no runtime test needed
# Checklist


 I added a changelog.md entry →  NO (not needed, since it’s only docs)
 Works with prebuild/EAS → no : not code related)
 Conforms with style guide → YES :  (simple doc cleanup)